### PR TITLE
Link to other apps/services

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -53,6 +53,7 @@ func (c *ClusterHandler) create(w http.ResponseWriter, r *http.Request) {
 		c.App.HandleError(w, Status(err), "create cluster error", err)
 		return
 	}
+	log(logger, "Created cluster %#v", cluster)
 
 	err = cluster.Create(c.App.Logger, c.App.Clientset)
 	if err != nil {

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -141,7 +141,7 @@ func buildDeployments(
 				if err != nil {
 					return nil, environment, err
 				}
-				deployment = NewDeployment(name, username, config.Image, ports, config.Environment, config.ReadinessProbe, config.VolumeMount)
+				deployment := NewDeployment(name, username, config.Image, ports, config.Environment, config.ReadinessProbe, config.VolumeMount)
 				for _, link := range config.Links {
 					deployment.Links = append(deployment.Links, createdDeployments[link])
 				}
@@ -252,7 +252,7 @@ func (c *Cluster) startDeploymentsAndItsServicesWithLinks(
 	clientset kubernetes.Interface,
 	deployments []*Deployment,
 ) error {
-	logger.Info("Creating linked services")
+	log(logger, "Creating linked services")
 	deploymentsNotReady := make(map[*Deployment]bool)
 	for _, deployment := range deployments {
 		deploymentsNotReady[deployment] = true

--- a/models/cluster_int_test.go
+++ b/models/cluster_int_test.go
@@ -51,24 +51,21 @@ apps:
 	)
 
 	mockCluster := func(username string) *Cluster {
+		svcDeployment1 := NewDeployment("test0", username, "svc1", ports, nil, nil, nil)
+		appDeployment1 := NewDeployment("test1", username, "app1", ports, nil, nil, nil)
+		appDeployment2 := NewDeployment("test2", username, "app2", ports, nil, nil, nil)
+		appDeployment3 := NewDeployment("test3", username, "app3", ports, nil, nil, nil)
+
 		return &Cluster{
-			Username:  username,
-			Namespace: namespace,
-			AppDeployments: []*Deployment{
-				NewDeployment("test1", username, "app1", ports, nil, nil, nil),
-				NewDeployment("test2", username, "app2", ports, nil, nil, nil),
-				NewDeployment("test3", username, "app3", ports, nil, nil, nil),
-			},
-			SvcDeployments: []*Deployment{
-				NewDeployment("test0", username, "svc1", ports, nil, nil, nil),
-			},
-			AppServices: []*Service{
-				NewService("test1", username, portMap, false),
-				NewService("test2", username, portMap, false),
-				NewService("test3", username, portMap, false),
-			},
-			SvcServices: []*Service{
-				NewService("test0", username, portMap, true),
+			Username:       username,
+			Namespace:      namespace,
+			AppDeployments: []*Deployment{appDeployment1, appDeployment2, appDeployment3},
+			SvcDeployments: []*Deployment{svcDeployment1},
+			K8sServices: map[*Deployment]*Service{
+				appDeployment1: NewService("test1", username, portMap, false),
+				appDeployment2: NewService("test2", username, portMap, false),
+				appDeployment3: NewService("test3", username, portMap, false),
+				svcDeployment1: NewService("test0", username, portMap, true),
 			},
 		}
 	}
@@ -84,8 +81,9 @@ apps:
 			mockedCluster := mockCluster(username)
 			Expect(cluster.AppDeployments).To(ConsistOf(mockedCluster.AppDeployments))
 			Expect(cluster.SvcDeployments).To(ConsistOf(mockedCluster.SvcDeployments))
-			Expect(cluster.AppServices).To(ConsistOf(mockedCluster.AppServices))
-			Expect(cluster.SvcServices).To(ConsistOf(mockedCluster.SvcServices))
+			for dp, svc := range mockedCluster.K8sServices {
+				Expect(cluster.K8sServices).To(HaveKeyWithValue(dp, svc))
+			}
 		})
 
 		It("should return error if cluster name not found", func() {

--- a/models/deployment.go
+++ b/models/deployment.go
@@ -84,6 +84,7 @@ type Deployment struct {
 	Environment    []*EnvVar
 	ReadinessProbe *Probe
 	Volume         *VolumeMount
+	Links          []*Deployment
 }
 
 //NewDeployment is the deployment ctor
@@ -105,6 +106,7 @@ func NewDeployment(
 		Environment:    environment,
 		ReadinessProbe: readinessProbe,
 		Volume:         volume,
+		Links:          []*Deployment{},
 	}
 }
 

--- a/models/types.go
+++ b/models/types.go
@@ -26,4 +26,5 @@ type ClusterAppConfig struct {
 	Environment    []*EnvVar    `yaml:"env,flow"`
 	ReadinessProbe *Probe       `yaml:"readinessProbe"`
 	VolumeMount    *VolumeMount `yaml:"volumeMount"`
+	Links          []string     `yaml:"links"`
 }


### PR DESCRIPTION
# Links

- New flag at the same level as image, ports and env called links.
- Links receive a list of names which are the app/service dependencies. 
- First, the services/apps with no dependencies are created as Deployment and exposed as Service. 
- Then, every service/app is checked to see if its dependencies were fulfilled. If yes, then it is created as Deployment and exposed as Service. 
- Circular dependencies will cause an infinite loop and the cluster will be deleted after timeout. 